### PR TITLE
Update Github reusable workflow to v0.0.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   build:
-    uses: artemrys/workflow-splunk-addon/.github/workflows/reusable-build-release.yaml@v0.0.4
+    uses: artemrys/workflow-splunk-addon/.github/workflows/reusable-build-release.yaml@v0.0.8


### PR DESCRIPTION
Updating to v0.0.8 brings in more Splunk Appinspect CLI checks.