### PR TITLE
Implement checkpoint_start_value to support TIMESTAMP checkpoints + linting and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ The field to use as the timestamp. The TIMESTAMP data type is recommended, but a
 
 ### Checkpoint Field
 
-The field whose largest value will be used as the `%checkpoint%` in the next search. The initial value is 0 and will be compared using `max()`, so you should to convert TIMESTAMP fields to a number using UNIX_MICROS and use that for checkpoints.
+The field whose largest value will be used as the `%checkpoint%` in the next search. The previous value will be saved in a file and compared with the current value using `max()` after being converted to string, so you can use any field type which is either a number or lexicographically comparable like TIMESTAMP.
 
-You can do this with a subquery such as:
+### Checkpoint start value
 
-```sql
-SELECT * FROM (
-    SELECT UNIX_MICROS(timestamp_column) as timestamp_column_micros, * FROM `table`
-) WHERE timestamp_column_micros > %checkpoint% 
-```
+The default initial value is 0 which works if you use a Unix time field and want to sync the whole table, but if you want to use TIMESTAMP you need to set a starting value which is compatible, for example `1970-01-01 00:00:00 UTC`.
+
+It's also useful if you don't want to sync the entire table and start from a specific value or date.
 
 ### Field Blacklist
 

--- a/bin/bigquery.py
+++ b/bin/bigquery.py
@@ -5,7 +5,7 @@ import time
 import base64
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
-from splunklib.modularinput import *
+from splunklib.modularinput import Argument, Event, EventWriter, Script, Scheme
 from google.cloud import bigquery
 from google.oauth2.service_account import Credentials
 from google.api_core.exceptions import BadRequest
@@ -14,40 +14,46 @@ from google.api_core.exceptions import BadRequest
 def fix_types(inputval):
     # this helper function converts BigQuery output into a format that is JSON-serialisable
     inputval_type = type(inputval).__name__
-    if inputval_type in ['NoneType']:
+    if inputval_type in ["NoneType"]:
         # None is not useful, so return blank.
-        return "" 
-    elif inputval_type in ['int','bool','str','float']:
+        return ""
+    elif inputval_type in ["int", "bool", "str", "float"]:
         # for these types, no need to do anything
-        return inputval 
-    elif inputval_type in ['Decimal']:
+        return inputval
+    elif inputval_type in ["Decimal"]:
         return float(inputval)
-    elif inputval_type in ['bytes']:
-        return str(base64.b64encode(inputval))[2:-1] # trim off the leading b' and trailing '
-    elif inputval_type in ['datetime', 'date', 'time']:
+    elif inputval_type in ["bytes"]:
+        return str(base64.b64encode(inputval))[
+            2:-1
+        ]  # trim off the leading b' and trailing '
+    elif inputval_type in ["datetime", "date", "time"]:
         return str(inputval)
-    elif inputval_type == 'list':
+    elif inputval_type == "list":
         # we need to process each subelement
         new_list = []
         for element in inputval:
             new_list.append(fix_types(element))
         return new_list
-    elif inputval_type == 'dict':
+    elif inputval_type == "dict":
         new_dict = {}
         for key in inputval.keys():
-            new_dict[key]=fix_types(inputval[key])
+            new_dict[key] = fix_types(inputval[key])
         return new_dict
     else:
-        raise Exception ("Encountered unexpected type: {typename}".format(typename=inputval_type)) 
+        raise Exception(
+            "Encountered unexpected type: {typename}".format(typename=inputval_type)
+        )
 
 
 def integer_to_epoch(ts):
-    while(ts > 9999999999):
-        ts=ts/10;
+    while ts > 9999999999:
+        ts = ts / 10
     return ts
+
 
 def timestamp_to_epoch(ts):
     return ts.timestamp()
+
 
 class Input(Script):
     MASK = "<encrypted>"
@@ -56,116 +62,154 @@ class Input(Script):
     def get_scheme(self):
 
         scheme = Scheme("Google BigQuery")
-        scheme.description = ("Executes a query against Google BigQuery and loads each row as an event")
+        scheme.description = (
+            "Executes a query against Google BigQuery and loads each row as an event"
+        )
         scheme.use_external_validation = False
         scheme.streaming_mode_xml = True
         scheme.use_single_instance = False
 
-        scheme.add_argument(Argument(
-            name="query",
-            title="Query (use %checkpoint% where required)",
-            data_type=Argument.data_type_string,
-            required_on_create=True
-        ))
-        scheme.add_argument(Argument(
-            name="service_account",
-            title="Service Account",
-            description="GCP Service Account as a single line of JSON",
-            data_type=Argument.data_type_string,
-            required_on_create=True
-        ))
-        scheme.add_argument(Argument(
-            name="time_field",
-            title="Time Field",
-            description="The column that contains the event time",
-            data_type=Argument.data_type_string,
-            required_on_create=False
-        ))
-        scheme.add_argument(Argument(
-            name="checkpoint_field",
-            title="Checkpoint Field",
-            description="The column that increases in newer events, last value will replace %checkpoint% in query.",
-            data_type=Argument.data_type_string,
-            required_on_create=False
-        ))
-        scheme.add_argument(Argument(
-            name="blacklist",
-            title="Field Blacklist",
-            description="Comma seperated list of columns that should not be indexed (such as the checkpoint field)",
-            data_type=Argument.data_type_string,
-            required_on_create=False
-        ))
+        scheme.add_argument(
+            Argument(
+                name="query",
+                title="Query (use %checkpoint% where required)",
+                data_type=Argument.data_type_string,
+                required_on_create=True,
+            )
+        )
+        scheme.add_argument(
+            Argument(
+                name="service_account",
+                title="Service Account",
+                description="GCP Service Account as a single line of JSON",
+                data_type=Argument.data_type_string,
+                required_on_create=True,
+            )
+        )
+        scheme.add_argument(
+            Argument(
+                name="time_field",
+                title="Time Field",
+                description="The column that contains the event time",
+                data_type=Argument.data_type_string,
+                required_on_create=False,
+            )
+        )
+        scheme.add_argument(
+            Argument(
+                name="checkpoint_field",
+                title="Checkpoint Field",
+                description="The column that increases in newer events, last value will replace %checkpoint% in query.",
+                data_type=Argument.data_type_string,
+                required_on_create=False,
+            )
+        )
+        scheme.add_argument(
+            Argument(
+                name="checkpoint_start_value",
+                title="Checkpoint start value",
+                description="Defaults to 0 if not set. If you want to start sync from a certain point or use a TIMESTAMP type field you can set a different value here, for example 1970-01-01 00:00:00 UTC",
+                data_type=Argument.data_type_string,
+                required_on_create=False,
+            )
+        )
+        scheme.add_argument(
+            Argument(
+                name="blacklist",
+                title="Field Blacklist",
+                description="Comma seperated list of columns that should not be indexed (such as the checkpoint field)",
+                data_type=Argument.data_type_string,
+                required_on_create=False,
+            )
+        )
         return scheme
 
     def stream_events(self, inputs, ew):
-        self.service.namespace['app'] = self.APP
-        
+        self.service.namespace["app"] = self.APP
+
         # Get Variables
         input_name, input_items = inputs.inputs.popitem()
         kind, name = input_name.split("://")
         checkpointfile = os.path.join(
             self._input_definition.metadata["checkpoint_dir"],
-            "".join([c for c in name if c.isalpha() or c.isdigit() or c==' ']).rstrip()
+            "".join(
+                [c for c in name if c.isalpha() or c.isdigit() or c == " "]
+            ).rstrip(),
         )
 
         query = input_items["query"]
-        time_field = input_items.get('time_field')
-        checkpoint_field = input_items.get('checkpoint_field')
-        blacklist = input_items.get('blacklist','').split(',')
-        
+        time_field = input_items.get("time_field")
+        checkpoint_field = input_items.get("checkpoint_field")
+        checkpoint_start_value = input_items.get("checkpoint_start_value") or "0"
+        blacklist = (input_items.get("blacklist") or "").split(",")
+
         # Password Encryption
         updates = {}
 
         for item in ["service_account"]:
-            stored_password = [x for x in self.service.storage_passwords if x.username == item and x.realm == name]
+            stored_password = [
+                x
+                for x in self.service.storage_passwords
+                if x.username == item and x.realm == name
+            ]
             if input_items[item] == self.MASK:
                 if len(stored_password) != 1:
-                    ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"Encrypted {item} was not found for {input_name}, reconfigure its value.\"")
+                    ew.log(
+                        EventWriter.ERROR,
+                        f'stanza="{name}" message="Encrypted {item} was not found for {input_name}, reconfigure its value."',
+                    )
                     return
                 input_items[item] = stored_password[0].content.clear_password
             else:
-                if(stored_password):
-                    self.service.storage_passwords.delete(username=item,realm=name)
-                self.service.storage_passwords.create(input_items[item],item,name)
+                if stored_password:
+                    self.service.storage_passwords.delete(username=item, realm=name)
+                self.service.storage_passwords.create(input_items[item], item, name)
                 updates[item] = self.MASK
-        if(updates):
-            self.service.inputs.__getitem__((name,kind)).update(**updates)
+        if updates:
+            self.service.inputs.__getitem__((name, kind)).update(**updates)
 
         # Apply Checkpoint
         checkpoint_value = None
-        if(checkpoint_field):
+        if checkpoint_field:
             try:
-                checkpoint_value = open(checkpointfile, "r").read()
-            except:
-                checkpoint_value = "0"
-            query = query.replace("%checkpoint%",checkpoint_value)            
+                with open(checkpointfile, "r") as file:
+                    checkpoint_value = file.read()
+            except FileNotFoundError:
+                checkpoint_value = checkpoint_start_value
+            query = query.replace("%checkpoint%", checkpoint_value)
 
         # Do the Query
-        service_account = json.loads(input_items['service_account']) #.replace('\\n', '\n')
-        project_id = service_account['project_id']
+        service_account = json.loads(input_items["service_account"])
+        project_id = service_account["project_id"]
         credentials = Credentials.from_service_account_info(service_account)
 
-        ew.log(EventWriter.INFO,f"stanza=\"{name}\" query=\"{query}\"")
+        ew.log(EventWriter.INFO, f'stanza="{name}" query="{query}"')
         try:
-            client = bigquery.Client(project_id,credentials)
+            client = bigquery.Client(project_id, credentials)
         except Exception as e:
-            ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"Unable to execute query as unable to obtain BigQuery client based on specified project ID and credentials.\" error=\"{e}\"")
-            exit(1)
+            ew.log(
+                EventWriter.ERROR,
+                f'stanza="{name}" message="Unable to execute query as unable to obtain BigQuery client based on specified project ID and credentials." error="{e}"',
+            )
+            sys.exit(1)
 
         query_epoch = time.time()
         try:
             query_job = client.query(query)
             results = query_job.result()
         except BadRequest as br:
-            ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"BadRequest\" error=\"{json.dumps(br.errors)}\"")
-            exit(1)
+            ew.log(
+                EventWriter.ERROR,
+                f'stanza="{name}" message="BadRequest" error="{json.dumps(br.errors)}"',
+            )
+            sys.exit(1)
         except Exception as e:
-            ew.log(EventWriter.ERROR,f"stanza=\"{name}\" error=\"{e}\"")
-            exit(2)
+            ew.log(EventWriter.ERROR, f'stanza="{name}" error="{e}"')
+            sys.exit(2)
 
         # Get Schema
         schema_obj = results.schema
-        
+
         # Verify whether the timestamp field exists
         time_field_index = 0
         if time_field is not None:
@@ -178,16 +222,25 @@ class Input(Script):
                         time_func = integer_to_epoch
                         break
                     else:
-                        ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"The specified timestamp column '{time_field}' exists, but is of type '{field.field_type}'.\"")
-                        #ew.log(EventWriter.ERROR,schema_obj)
-                        exit(3)
+                        ew.log(
+                            EventWriter.ERROR,
+                            f"stanza=\"{name}\" message=\"The specified timestamp column '{time_field}' exists, but is of type '{field.field_type}'.\"",
+                        )
+                        # ew.log(EventWriter.ERROR,schema_obj)
+                        sys.exit(3)
                 time_field_index += 1
             else:
-                ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"The specified timestamp column '{time_field}' was not returned in the query results.\"")
-                #ew.log(EventWriter.ERROR,schema_obj)
-                exit(4)
+                ew.log(
+                    EventWriter.ERROR,
+                    f'stanza="{name}" message="The specified timestamp column \'{time_field}\' was not returned in the query results."',
+                )
+                # ew.log(EventWriter.ERROR,schema_obj)
+                sys.exit(4)
         else:
-            ew.log(EventWriter.WARN,"stanza=\"{name}\" message=\"No time field is being used\"")
+            ew.log(
+                EventWriter.WARN,
+                'stanza="{name}" message="No time field is being used"',
+            )
 
         checkpoint_next = checkpoint_value
         if checkpoint_field is not None:
@@ -195,13 +248,19 @@ class Input(Script):
                 if field.name == checkpoint_field:
                     break
             else:
-                ew.log(EventWriter.ERROR,f"stanza=\"{name}\" message=\"The specified checkpoint column '{checkpoint_field}' was not returned in the query results.\"")
-                #ew.log(EventWriter.ERROR,schema_obj)
-                exit(5)
+                ew.log(
+                    EventWriter.ERROR,
+                    f'stanza="{name}" message="The specified checkpoint column \'{checkpoint_field}\' was not returned in the query results."',
+                )
+                # ew.log(EventWriter.ERROR,schema_obj)
+                sys.exit(5)
         else:
-            ew.log(EventWriter.WARN,"stanza=\"{name}\" message=\"No checkpoint field is being used\"")
+            ew.log(
+                EventWriter.WARN,
+                'stanza="{name}" message="No checkpoint field is being used"',
+            )
 
-        if(input_items["sourcetype"].endswith("tsv")):
+        if input_items["sourcetype"].endswith("tsv"):
             for page in results.pages:
                 for row in page:
                     # Get time
@@ -213,21 +272,35 @@ class Input(Script):
 
                     # Find next checkpoint
                     if checkpoint_field is not None:
-                        checkpoint_next = max(checkpoint_next,str(row[checkpoint_field]))
+                        checkpoint_next = max(
+                            checkpoint_next, str(row[checkpoint_field])
+                        )
 
                     # Write the event
-                    ew.write_event(Event(
-                        time = event_time,
-                        data = "\t".join(list(map(lambda x: str(fix_types(x)), row.values())))+"\n"
-                    ))
+                    ew.write_event(
+                        Event(
+                            time=event_time,
+                            data="\t".join(
+                                [str(fix_types(value)) for value in row.values()]
+                            )
+                            + "\n",
+                        )
+                    )
         else:
             for page in results.pages:
-                ew.log(EventWriter.DEBUG,f"stanza=\"{name}\" message=\"Getting next page, checkpoint is {checkpoint_next}\"")
+                ew.log(
+                    EventWriter.DEBUG,
+                    f'stanza="{name}" message="Getting next page, checkpoint is {checkpoint_next}"',
+                )
                 for row in page:
                     # Turn the rows in to a dictionary with correct types
                     data = {}
-                    for column,value in zip(results.schema,row.values()):
-                        if value != None and value != [] and column.name not in blacklist:
+                    for column, value in zip(results.schema, row.values()):
+                        if (
+                            value is not None
+                            and value != []
+                            and column.name not in blacklist
+                        ):
                             data[column.name] = fix_types(value)
 
                     # Get time
@@ -236,25 +309,34 @@ class Input(Script):
                     else:
                         # If no time_field is specified then we will simply reuse the query epoch as the event_timestamp that is written to Splunk
                         event_time = query_epoch
-                    
+
                     # Find next checkpoint
                     if checkpoint_field is not None:
-                        checkpoint_next = max(checkpoint_next,str(row[checkpoint_field]))
+                        checkpoint_next = max(
+                            checkpoint_next, str(row[checkpoint_field])
+                        )
 
                     # Write the event
-                    ew.write_event(Event(
-                        time = event_time,
-                        data = json.dumps(data, separators=(',', ':'))
-                    ))
+                    ew.write_event(
+                        Event(
+                            time=event_time,
+                            data=json.dumps(data, separators=(",", ":")),
+                        )
+                    )
 
         # Save Checkpoint if its not the default
         if checkpoint_field is not None:
             if checkpoint_next != checkpoint_value:
-                ew.log(EventWriter.INFO,f"stanza=\"{name}\" message=\"Saving checkpoint {checkpoint_next}\"")
-                open(checkpointfile, "w").write(checkpoint_next)
+                ew.log(
+                    EventWriter.INFO,
+                    f'stanza="{name}" message="Saving checkpoint {checkpoint_next}"',
+                )
+                with open(checkpointfile, "w") as file:
+                    file.write(checkpoint_next)
 
         ew.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     exitcode = Input().run(sys.argv)
     sys.exit(exitcode)


### PR DESCRIPTION
Apologies, this ended up being a huge diff because I use [Black](https://black.readthedocs.io/en/stable/index.html) formatter by default in my IDE and it made a lot of changes. Please let me know if you'd rather have these changes split out in a different PR or if you absolutely don't want them!

I also did a few small lint / style changes [Snyk Code](https://snyk.io/code-checker/python/) was complaining about, I'll highlight these in comments.

As for the substance of the PR, I realised there isn't really a safe way to remove the checkpoint condition from the query as we'd need to somehow delete the whole comparison from the query string. Also, at that point the schema isn't loaded yet, so can't automatically pick an appropriate default. So I introduced a new input called `checkpoint_start_value` which would make it possible to set it to the `1970-01-01 00:00:00 UTC` format for TIMESTAMP type, but would also solve another problem I had to work around in queries themselves which is that we can't backfill all the historical data for some huge tables.

I was also thinking about adding tests, but definitely didn't want to add even more to this PR. If you think that would be a good idea I can try to make some time and get something going in the coming weeks?