### PR TITLE
Cap splunk-sdk <3, declare Python 3.9 support

### DIFF
--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -3,5 +3,5 @@ disabled = 0
 interval = 14400
 sourcetype = google:bigquery:json
 python.version = python3
-python.required = 3.9, 3.13
+python.required = 3.9
 checkpoint_start = 0

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -3,4 +3,5 @@ disabled = 0
 interval = 14400
 sourcetype = google:bigquery:json
 python.version = python3
+python.required = 3.9, 3.13
 checkpoint_start = 0

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,1 +1,2 @@
 splunk-sdk>=2.1.1,<3
+setuptools<81

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,1 +1,1 @@
-splunk-sdk
+splunk-sdk>=2.1.1,<3


### PR DESCRIPTION
## What
- Cap `splunk-sdk` in `lib/requirements.txt` to `>=2.1.1,<3`
  - `splunk-sdk` 3.0.0 requires Python 3.13 and breaks on 3.9; an unpinned line risks a 3.13 build host silently pulling the incompatible major version.
- Declare Python 3.9 support in `default/inputs.conf`
  - Added `python.required = 3.9` to the `[bigquery]` stanza (kept `python.version = python3`).
  - Scoped to 3.9 only: the vendored `google-cloud-bigquery` dependency tree under `lib/` (old `urllib3` with a bundled `six`, pre-3.13-era code) isn't 3.13-compatible yet. `bin/bigquery.py` forces this vendored tree onto `sys.path` ahead of anything pip-installable, so 3.13 support needs a re-vendor of that stack, filed as a separate follow-up.
- Added `setuptools<81` to `lib/requirements.txt`
  - `bin/bigquery.py`'s import chain (`google.api_core.client_info`) needs `pkg_resources`, which `setuptools` 81+ dropped. This previously only worked because Splunk's bundled Python 3.9 runtime ships an older setuptools.

## Verify
```
VERIFY_RESULT: py3.9=PASS py3.13=FAIL
```
py3.13 FAIL is expected and out of scope for this PR — it's the vendored dependency stack described above, tracked separately for re-vendor.

<details><summary>Full narrative / original brief</summary>

Splunk is transitioning Python 3.9 -> 3.13. `splunk-sdk` 2.x runs on both, but 3.0.0 requires Python 3.13 and can't run on 3.9. This add-on pinned `splunk-sdk` unpinned, so a 3.13 build host would silently pull the incompatible 3.0.0.

Initial investigation found the harness failing on both 3.9 and 3.13:
- py3.9: `ModuleNotFoundError: No module named 'pkg_resources'` — fixed via `setuptools<81` pin.
- py3.13: `ModuleNotFoundError: No module named 'urllib3.packages.six.moves'` — caused by the app's own `sys.path.insert(0, ../lib)` always prioritizing a statically vendored, pre-2.0 `urllib3` (with a bundled `six`) over anything `requirements.txt` could install. Confirmed this can't be fixed by adding packages to `requirements.txt`.

Decision (maintainer): ship Python 3.9-only for now; 3.13 needs a dedicated re-vendor of the `google-cloud-bigquery` dependency stack, filed as a follow-up.
</details>
