### PR TITLE
Add CI: build + local AppInspect precert

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  validate:
+    uses: Bre77/splunk_nats/.github/workflows/_reusable-build-appinspect.yml@main
+    with:
+      app_dir: "."
+      use_ucc_gen: false
+      build_command: "./.build.sh"
+      package_glob: "../*.spl"
+      splunk_python_version: "3.9"
+      fail_on: "errors"


### PR DESCRIPTION
## Intent

- Wire this add-on into the fleet's shared CI: `.github/workflows/validate.yml` calls
  `Bre77/splunk_nats/.github/workflows/_reusable-build-appinspect.yml@main` to build the
  `.spl` and run a local (credential-free) AppInspect precert on every push/PR, matching
  the caller pattern already used by the rest of the fleet's plain TAs (e.g.
  `atlassian_audit`).
- `package_glob` is set to `"../*.spl"`: `.build.sh` `cd ..`s before writing the archive with
  a relative `OUTPUT` path, so the `.spl` lands one directory up from `app_dir`, not inside it.
  Verified by running `.build.sh` locally and inspecting the result - `tar tzf` shows
  `TA-googlebigquery/` as the sole top-level entry, `lib/` has zero native `.so` files, no
  `__pycache__`, and no exec bits outside `bin/`.
- No version bump and no changes to vendored libraries or the query code - 1.2.0 is already
  merged and validated; this PR is CI wiring only.
